### PR TITLE
Fix stretching of the copyright notice

### DIFF
--- a/cozycast-server/src/main/resources/static/css/styles.css
+++ b/cozycast-server/src/main/resources/static/css/styles.css
@@ -123,6 +123,8 @@ html, body, #pagecontent, #videosizer {
     grid-column: span 3;
     color: lightgray;
     font-size: .5em;
+    align-self: center;
+    justify-self: start;
 }
 
 .message {


### PR DESCRIPTION
Clickable area of the copyright notice at bottom left it far larger than the text of the link, causing some annoyance when clicking on cozycast.